### PR TITLE
Use New Embeddings Actor

### DIFF
--- a/external/bioma_js/bioma.js
+++ b/external/bioma_js/bioma.js
@@ -44,7 +44,6 @@ class BiomaInterface {
 
   async createActor(id) {
     const actor = await this.db.select(id);
-    console.debug("actor", actor);
     if (actor) {
       return actor;
     }

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,25 +5,16 @@ import { BaileysProvider as Provider } from "@builderbot/provider-baileys";
 import { httpInject } from "@builderbot-plugins/openai-assistants";
 import { flow } from "./flows";
 import { initDb } from "./database/surreal";
-import { Fact, getFacts, setupFactsLiveQuery } from "./models/Session";
 
 const VERTEX_BOT_PORT = process.env?.VERTEX_BOT_PORT ?? 3008;
 
 let contacts = {};
-
-export let facts: Fact[] = [];
 
 const main = async () => {
   const adapterProvider = createProvider(Provider, { writeMyself: "both" });
   const adapterDB = new Database();
 
   await initDb();
-
-  facts = await getFacts();
-
-  await setupFactsLiveQuery((updatedFacts) => {
-    facts = updatedFacts;
-  });
 
   const { httpServer, handleCtx } = await createBot({
     flow: flow,

--- a/src/flows/welcomeFlow.flow.ts
+++ b/src/flows/welcomeFlow.flow.ts
@@ -95,7 +95,6 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
 
       // TODO: Get conversation only once.
       const result = await handleConversation(groupId);
-      console.debug("result", result);
       const { latestMessagesEmbeddings, conversation } = Array.isArray(result)
         ? { latestMessagesEmbeddings: [], conversation: null }
         : result;
@@ -158,8 +157,10 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
           body,
           "conversation",
           10,
-          0.5
+          0.7
         );
+
+        console.debug("similarityResult", similarityResult);
 
         let topSimilarities: Array<{
           role: string;
@@ -167,8 +168,8 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
           similarity: number;
         }> = [];
 
-        if (similarityResult.msg && similarityResult.msg.similarities) {
-          topSimilarities = similarityResult.msg.similarities
+        if (similarityResult.msg && Array.isArray(similarityResult.msg)) {
+          topSimilarities = similarityResult.msg
             .map((sim) => {
               const matchingMessage = olderMessages.find(
                 (msg) => msg.msg === sim.text
@@ -262,13 +263,14 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
           similarity: number;
         }> = [];
 
-        if (factSimilarityResult.msg && factSimilarityResult.msg.similarities) {
-          topSimilarFacts = factSimilarityResult.msg.similarities.map(
-            (sim) => ({
-              content: sim.text,
-              similarity: sim.similarity,
-            })
-          );
+        if (
+          factSimilarityResult.msg &&
+          Array.isArray(factSimilarityResult.msg)
+        ) {
+          topSimilarFacts = factSimilarityResult.msg.map((sim) => ({
+            content: sim.text,
+            similarity: sim.similarity,
+          }));
 
           // Log the top similarity score and content for facts
           if (topSimilarFacts.length > 0) {

--- a/src/flows/welcomeFlow.flow.ts
+++ b/src/flows/welcomeFlow.flow.ts
@@ -146,7 +146,6 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
         }
 
         // TODO: Figure out how to do embeddings only once. No need to do it twice (here and in VV DB).
-        const queryEmbedding = await generateEmbedding(body);
 
         // Convert latestMessagesEmbeddings to an array if it's not already
         const allMessages = Array.isArray(latestMessagesEmbeddings)

--- a/src/flows/welcomeFlow.flow.ts
+++ b/src/flows/welcomeFlow.flow.ts
@@ -157,10 +157,8 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
           body,
           "conversation",
           10,
-          0.7
+          0.5
         );
-
-        console.debug("similarityResult", similarityResult);
 
         let topSimilarities: Array<{
           role: string;
@@ -216,7 +214,7 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
             Array.isArray(rerankedMessagesResult.msg)
           ) {
             rerankedOlderMessages = rerankedMessagesResult.msg
-              .sort((a, b) => b.score - a.score)
+              .sort((a, b) => a.score - b.score) // Changed to ascending order
               .map((item) => {
                 const message = messagesToRerank[item.index];
                 const originalMessage = topSimilarities.find(

--- a/src/flows/welcomeFlow.flow.ts
+++ b/src/flows/welcomeFlow.flow.ts
@@ -70,7 +70,7 @@ export async function handleConversation(
     const [latestMessagesEmbeddings] = await db.query<Message[]>(`
       SELECT 
           *,
-          (->chat_message_role->role)[0] AS role
+          (->chat_message_role.out)[0] AS role
       FROM (
           SELECT ->conversation_chat_messages->chat_message AS chat_message 
           FROM conversation 
@@ -95,6 +95,7 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
 
       // TODO: Get conversation only once.
       const result = await handleConversation(groupId);
+      console.debug("result", result);
       const { latestMessagesEmbeddings, conversation } = Array.isArray(result)
         ? { latestMessagesEmbeddings: [], conversation: null }
         : result;

--- a/src/flows/welcomeFlow.flow.ts
+++ b/src/flows/welcomeFlow.flow.ts
@@ -263,7 +263,8 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
 
         if (
           factSimilarityResult.msg &&
-          Array.isArray(factSimilarityResult.msg)
+          Array.isArray(factSimilarityResult.msg) &&
+          factSimilarityResult.msg.length > 0
         ) {
           topSimilarFacts = factSimilarityResult.msg.map((sim) => ({
             content: sim.text,
@@ -271,17 +272,13 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
           }));
 
           // Log the top similarity score and content for facts
-          if (topSimilarFacts.length > 0) {
-            const topSimilarityFact = topSimilarFacts[0];
-            console.debug(
-              `Top fact similarity score: ${topSimilarityFact.similarity}`
-            );
-            console.debug(
-              `Top fact similarity content: ${topSimilarityFact.content}`
-            );
-          } else {
-            console.debug("No facts above similarity threshold");
-          }
+          const topSimilarityFact = topSimilarFacts[0];
+          console.debug(
+            `Top fact similarity score: ${topSimilarityFact.similarity}`
+          );
+          console.debug(
+            `Top fact similarity content: ${topSimilarityFact.content}`
+          );
 
           // Rerank the top similar facts
           const factsToRerank = topSimilarFacts.map(({ content }) => content);
@@ -299,6 +296,8 @@ export const welcomeFlow = addKeyword(EVENTS.WELCOME).addAction(
               rerankedFactsResult
             );
           }
+        } else {
+          console.debug("No facts above similarity threshold");
         }
 
         const relevantFactsText =

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -72,7 +72,7 @@ export class Session {
     const messageContents = messages.map((msg) => msg.content);
     const embeddingResult = await createEmbeddings(
       messageContents,
-      EMBEDDING_MODEL
+      "conversation"
     );
 
     const createQueries = messages.map((msg, index) => {

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -1,6 +1,6 @@
 import { getDb } from "~/database/surreal";
 import "dotenv/config";
-import createEmbeddings from "~/services/actors/embeddings";
+import { createEmbeddings } from "~/services/actors/embeddings";
 
 const EMBEDDING_MODEL = process.env.EMBEDDING_MODEL;
 

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -77,16 +77,11 @@ export class Session {
 
     const createQueries = messages.map((msg, index) => {
       const query = `
-        LET $message = CREATE message SET content = ${JSON.stringify(
+        LET $chat_message = CREATE chat_message SET msg = ${JSON.stringify(
           msg.content
         )}, created_at = time::now();
-        LET $embedding = CREATE embedding SET vector = ${JSON.stringify(
-          embeddingResult.msg.embeddings[index]
-        )};
-        RELATE conversation:${conversation}->conversation_messages->$message;
-        RELATE $message->message_role->role:${msg.role};
-        RELATE $message->message_embedding->$embedding;
-        RELATE $embedding->embedding_embedding_model->embedding_model:\`${EMBEDDING_MODEL}\`;
+        RELATE conversation:${conversation}->conversation_chat_messages->$chat_message;
+        RELATE $chat_message->chat_message_role->role:${msg.role};
       `
         .replace(/\n/g, " ")
         .trim();

--- a/src/models/Session.ts
+++ b/src/models/Session.ts
@@ -153,23 +153,3 @@ export class Session {
 }
 
 export const sessions = new Map<string, Session>();
-
-export async function getFacts() {
-  const db = getDb();
-  const facts = await db.query<Fact[]>("SELECT * FROM fact");
-  return facts;
-}
-
-export async function setupFactsLiveQuery(callback: (facts: Fact[]) => void) {
-  const db = getDb();
-
-  try {
-    const liveQuery = await db.live<Fact>("fact", (data) => {
-      getFacts().then(callback);
-    });
-
-    return liveQuery;
-  } catch (error) {
-    console.error("Error setting up live query:", error);
-  }
-}

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -67,4 +67,59 @@ async function createEmbeddings(
   }
 }
 
-export default createEmbeddings;
+type SimilarityResult = {
+  err: undefined | string;
+  id: RecordId;
+  msg: {
+    similarities: Array<{
+      text: string;
+      similarity: number;
+    }>;
+  };
+  name: string;
+  rx: RecordId;
+  tx: RecordId;
+};
+
+async function topSimilarity(
+  query: string | number[],
+  tag?: string,
+  k: number = 5,
+  threshold: number = 0.7
+): Promise<SimilarityResult> {
+  try {
+    const vertexBotWspId = bioma.createActorId(
+      "/vertex-bot-wsp",
+      "vertex::VertexBotWSP"
+    );
+    const vertexBotWsp = await bioma.createActor(vertexBotWspId);
+
+    const embeddingsId = bioma.createActorId(
+      "/embeddings",
+      "bioma_llm::embeddings::Embeddings"
+    );
+
+    const topKMessage = {
+      query: typeof query === "string" ? { Text: query } : { Embedding: query },
+      tag: tag,
+      k: k,
+      threshold: threshold,
+    };
+
+    const messageId = await bioma.sendMessage(
+      vertexBotWspId,
+      embeddingsId,
+      "bioma_llm::embeddings::TopK",
+      topKMessage
+    );
+
+    const reply = await bioma.waitForReply(messageId, 10000);
+
+    return reply as SimilarityResult;
+  } catch (error) {
+    console.error("Error in topSimilarity:", error);
+    throw error;
+  }
+}
+
+export { createEmbeddings, topSimilarity };

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -31,7 +31,8 @@ type EmbeddingResult = {
 
 async function createEmbeddings(
   texts: string[],
-  model: string
+  tag: string,
+  model?: string
 ): Promise<EmbeddingResult> {
   try {
     const vertexBotWspId = bioma.createActorId(
@@ -47,7 +48,7 @@ async function createEmbeddings(
 
     const createEmbeddingsMessage = {
       texts: texts,
-      model_name: model,
+      tag: tag,
     };
 
     const messageId = await bioma.sendMessage(

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -2,20 +2,20 @@ import { BiomaInterface } from "external/bioma_js/bioma.js";
 import { RecordId } from "surrealdb.js";
 import "dotenv/config";
 
-const VV_DB_URL = `${process.env.VV_DB_PROTOCOL}://${process.env.VV_DB_HOST}:${process.env.VV_DB_PORT}`;
-const VV_DB_NAMESPACE = process.env.VV_DB_NAMESPACE;
-const VV_DB_DATABASE = process.env.VV_DB_DATABASE;
-const VV_DB_USER = process.env.VV_DB_USER;
-const VV_DB_PASSWORD = process.env.VV_DB_PASSWORD;
+const BIOMA_DB_URL = `${process.env.BIOMA_DB_PROTOCOL}://${process.env.BIOMA_DB_HOST}:${process.env.BIOMA_DB_PORT}`;
+const BIOMA_DB_NAMESPACE = process.env.BIOMA_DB_NAMESPACE;
+const BIOMA_DB_DATABASE = process.env.BIOMA_DB_DATABASE;
+const BIOMA_DB_USER = process.env.BIOMA_DB_USER;
+const BIOMA_DB_PASSWORD = process.env.BIOMA_DB_PASSWORD;
 
 const bioma = new BiomaInterface();
 
 await bioma.connect(
-  VV_DB_URL || "ws://127.0.0.1:8000",
-  VV_DB_NAMESPACE || "dev",
-  VV_DB_DATABASE || "bioma",
-  VV_DB_USER || "root",
-  VV_DB_PASSWORD || "root"
+  BIOMA_DB_URL || "ws://127.0.0.1:8000",
+  BIOMA_DB_NAMESPACE || "dev",
+  BIOMA_DB_DATABASE || "bioma",
+  BIOMA_DB_USER || "root",
+  BIOMA_DB_PASSWORD || "root"
 );
 
 type EmbeddingResult = {

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -89,7 +89,7 @@ async function topSimilarity(
 ): Promise<SimilarityResult> {
   try {
     const vertexBotWspId = bioma.createActorId(
-      "/vertex-bot-wsp",
+      "/vertex-bot-wsp-embeddings",
       "vertex::VertexBotWSP"
     );
     const vertexBotWsp = await bioma.createActor(vertexBotWspId);

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -43,7 +43,7 @@ async function createEmbeddings(
 
     const embeddingsId = bioma.createActorId(
       "/embeddings",
-      "embeddings::embeddings::Embeddings"
+      "bioma_llm::embeddings::Embeddings"
     );
 
     const createEmbeddingsMessage = {
@@ -54,7 +54,7 @@ async function createEmbeddings(
     const messageId = await bioma.sendMessage(
       vertexBotWspId,
       embeddingsId,
-      "embeddings::embeddings::GenerateEmbeddings",
+      "bioma_llm::embeddings::GenerateEmbeddings",
       createEmbeddingsMessage
     );
 

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -2,20 +2,20 @@ import { BiomaInterface } from "external/bioma_js/bioma.js";
 import { RecordId } from "surrealdb.js";
 import "dotenv/config";
 
-const BIOMA_DB_URL = `${process.env.BIOMA_DB_PROTOCOL}://${process.env.BIOMA_DB_HOST}:${process.env.BIOMA_DB_PORT}`;
-const BIOMA_DB_NAMESPACE = process.env.BIOMA_DB_NAMESPACE;
-const BIOMA_DB_DATABASE = process.env.BIOMA_DB_DATABASE;
-const BIOMA_DB_USER = process.env.BIOMA_DB_USER;
-const BIOMA_DB_PASSWORD = process.env.BIOMA_DB_PASSWORD;
+const VV_DB_URL = `${process.env.VV_DB_PROTOCOL}://${process.env.VV_DB_HOST}:${process.env.VV_DB_PORT}`;
+const VV_DB_NAMESPACE = process.env.VV_DB_NAMESPACE;
+const VV_DB_DATABASE = process.env.VV_DB_DATABASE;
+const VV_DB_USER = process.env.VV_DB_USER;
+const VV_DB_PASSWORD = process.env.VV_DB_PASSWORD;
 
 const bioma = new BiomaInterface();
 
 await bioma.connect(
-  BIOMA_DB_URL || "ws://127.0.0.1:8000",
-  BIOMA_DB_NAMESPACE || "dev",
-  BIOMA_DB_DATABASE || "bioma",
-  BIOMA_DB_USER || "root",
-  BIOMA_DB_PASSWORD || "root"
+  VV_DB_URL || "ws://127.0.0.1:8000",
+  VV_DB_NAMESPACE || "dev",
+  VV_DB_DATABASE || "bioma",
+  VV_DB_USER || "root",
+  VV_DB_PASSWORD || "root"
 );
 
 type EmbeddingResult = {
@@ -113,7 +113,7 @@ async function topSimilarity(
       topKMessage
     );
 
-    const reply = await bioma.waitForReply(messageId, 10000);
+    const reply = await bioma.waitForReply(messageId, 60000);
 
     return reply as SimilarityResult;
   } catch (error) {

--- a/src/services/actors/embeddings.ts
+++ b/src/services/actors/embeddings.ts
@@ -70,12 +70,10 @@ async function createEmbeddings(
 type SimilarityResult = {
   err: undefined | string;
   id: RecordId;
-  msg: {
-    similarities: Array<{
-      text: string;
-      similarity: number;
-    }>;
-  };
+  msg: Array<{
+    text: string;
+    similarity: number;
+  }>;
   name: string;
   rx: RecordId;
   tx: RecordId;


### PR DESCRIPTION
# Cosine Similarity and Embedding Creation for Messages & Facts

## Changes:
- Perform cosine similarity with the embeddings actor for both messages and facts. We get top `20` with threshold `0.5`.
- After retrieving the top N (`20`) results above a threshold X (`0.5`), rerank the results and get the top Y (`10`).
- Create embeddings using the embeddings actor before saving the messages to `VV DB`.

## Caveats:
- **Role Matching in Cosine Similarity:** When performing cosine similarity for messages, we receive back text results without any indication of the associated role (e.g., `system`, `user`, `assistant`). As a temporary workaround, we match the returned text with the corresponding text in our local messages object, which contains the role information. If there's a match, we assume that’s the top N message.
  - *Note:* This is a limitation due to adapting to the new embeddings actor and its intended use. It's assumed that relationships will be implemented in the near future, which should help resolve these issues.

- **Scores:** Scores are not what it was expected. For a query mentioning a related word or meaning to a text (eg. "me gusta la comida saludable, que recomiendas" and the text "Platos fitness Cazuela de hongos con berenjena en salsa hoisin: Trozos de berenjena y hongo shitake salteados al wok con salsa soya y sake. Servido con cebollin y ajonjolí blanco. Precio: $10.5") it does not quite receive the proper score comopared to other less related texts (eg. "Entrada Wantan (Camarón, cangrejo y cerdo asado): Orden de wantan fritos crujientes, elaborados con una tela hecha a base de harina de trigo y rellena con la carne de su elección sazonada con el secreto de la casa. Son acompañados con salsa agridulce y salsa maiti, que es salsa de soya con un picado de cebollín. Precio: $6").